### PR TITLE
Fix issue where route params are seen as regex due to passing to glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sveltekit-openapi-generator",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Generate OpenAPI 3.0 specifications from SvelteKit server endpoints using JSDoc @swagger annotations",
 	"type": "module",
 	"license": "MIT",

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -134,7 +134,7 @@ export function generateSpec(options: GeneratorOptions): OpenAPIV3.Document {
 					openapi: '3.0.0',
 					info: baseSpec.info
 				},
-				apis: [apiPath],
+				apis: [apiPath.replaceAll('[', '\\[').replaceAll(']', '\\]')],
 				failOnErrors
 			}) as OpenAPIV3.Document;
 


### PR DESCRIPTION

Fixed the issue where route params are being seen as a regex due to passing to glob by swaggerJsdoc module.

Fixes #3 

